### PR TITLE
check-environment: fix fuse3 test program

### DIFF
--- a/tuxmake/runtime/bin/tuxmake-check-environment
+++ b/tuxmake/runtime/bin/tuxmake-check-environment
@@ -120,10 +120,11 @@ int main(int argc, char *argv[])
 PROGRAM
 
 my $fuse_program_fuse3 = <<PROGRAM;
+#define FUSE_USE_VERSION 30
 #include <fuse3/fuse.h>
 int main(int argc, char *argv[])
 {
-	return fuse_main(argc, argv, NULL);
+	return fuse_main(argc, argv, NULL, NULL);
 }
 PROGRAM
 


### PR DESCRIPTION
The fuse3 test program fails to compile:

  error: implicit declaration of function 'fuse_main'

fuse3 requires FUSE_USE_VERSION defined and fuse_main takes 4 arguments, not 3.

Fixes: 87e6392225f7 ("check-environment: add fuse3 detection and cross pkg-config fallback")