### PR TITLE
check-environment: fix fuse3 test on 32-bit architectures

### DIFF
--- a/tuxmake/runtime/bin/tuxmake-check-environment
+++ b/tuxmake/runtime/bin/tuxmake-check-environment
@@ -120,6 +120,7 @@ int main(int argc, char *argv[])
 PROGRAM
 
 my $fuse_program_fuse3 = <<PROGRAM;
+#define _FILE_OFFSET_BITS 64
 #define FUSE_USE_VERSION 30
 #include <fuse3/fuse.h>
 int main(int argc, char *argv[])


### PR DESCRIPTION
The fuse3 test program fails on i386 cross-compilation:

  error: static assertion failed: "fuse: off_t must be 64bit"

fuse3 requires _FILE_OFFSET_BITS=64. Without it 32-bit architectures like i386 have 32-bit off_t and the assertion in fuse_common.h fails.

Fixes: dbd8fdb18210 ("check-environment: fix fuse3 test program")