### PR TITLE
kselftest: pass KDIR to enable out-of-tree module builds

### DIFF
--- a/test/test_target.py
+++ b/test/test_target.py
@@ -213,6 +213,11 @@ class TestKselftest:
         kselftest = Kselftest("kselftest", build)
         assert not getattr(kselftest, "exclude_build_makevars", set())
 
+    def test_kdir_set_to_build_dir(self, build):
+        build.toolchain.name = "gcc-14"
+        kselftest = Kselftest("kselftest", build)
+        assert kselftest.makevars.get("KDIR") == "{build_dir}"
+
 
 class TestCompression:
     def test_invalid_compression(self):

--- a/tuxmake/target/kselftest.ini
+++ b/tuxmake/target/kselftest.ini
@@ -7,6 +7,7 @@ commands = {make} -C tools/testing/selftests install
 
 [makevars]
 INSTALL_PATH = {build_dir}/kselftest_install
+KDIR = {build_dir}
 
 [artifacts]
 kselftest.tar{z_ext} = kselftest.tar{z_ext}


### PR DESCRIPTION
Some kselftest suites (e.g. livepatch) include kernel modules built via TEST_GEN_MODS_DIR. The test_modules Makefile defaults KDIR to the host kernel build directory, which does not exist during cross-compilation. This causes the module build to be silently skipped, and the subsequent install step fails when rsync cannot find any .ko files.

Pass KDIR={build_dir} so that test modules are built against the kernel being compiled.