### PR TITLE
kselftest: allow partial build failures

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1046,6 +1046,19 @@ class TestKselftest:
         names = [t.name for t in build.targets]
         assert names == ["config", "kselftest-merge", "default", "kernel"]
 
+    def test_nonfatal_continues_on_failure(self, linux, mocker):
+        b = Build(tree=linux, targets=["config"])
+        target = mocker.MagicMock()
+        target.name = "kselftest"
+        target.nonfatal = True
+        target.dependencies = []
+        target.preconditions = []
+        target.commands = [Command(["false"]), Command(["true"])]
+        mocker.patch.object(b, "run_cmd", side_effect=[False, True])
+        mocker.patch.object(b, "check_artifacts", return_value=True)
+        result = b.build(target)
+        assert result.passed
+
 
 class TestHeaders:
     def test_basics(self, linux):

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -213,6 +213,18 @@ class TestKselftest:
         kselftest = Kselftest("kselftest", build)
         assert not getattr(kselftest, "exclude_build_makevars", set())
 
+    def test_kselftest_is_nonfatal(self, build):
+        kselftest = Kselftest("kselftest", build)
+        assert kselftest.nonfatal
+
+    def test_kselftest_bpf_is_nonfatal(self, build):
+        kselftest_bpf = Kselftest("kselftest-bpf", build)
+        assert kselftest_bpf.nonfatal
+
+    def test_config_is_not_nonfatal(self, build):
+        config = Target("config", build)
+        assert not config.nonfatal
+
     def test_kdir_set_to_build_dir(self, build):
         build.toolchain.name = "gcc-14"
         kselftest = Kselftest("kselftest", build)

--- a/tuxmake/build.py
+++ b/tuxmake/build.py
@@ -599,8 +599,11 @@ class Build:
                 interactive=cmd.interactive,
                 exclude_build_makevars=exclude_keys,
             ):
-                fail = True
-                break
+                if target.nonfatal:
+                    self.log("W: command failed, continuing (nonfatal target)")
+                else:
+                    fail = True
+                    break
 
         if not fail and not self.check_artifacts(target):
             fail = True

--- a/tuxmake/target.py
+++ b/tuxmake/target.py
@@ -80,6 +80,7 @@ class Target(ConfigurableObject):
         self.runs_after = self.config["target"].get("runs_after", "").split()
         self.preconditions = self.__split_cmds__("target", "preconditions")
         self.commands = self.__split_cmds__("target", "commands")
+        self.nonfatal = self.config["target"].get("nonfatal", "").lower() == "true"
         self.kconfig_add = self.__split_kconfigs__()
         try:
             artifacts = dict(self.config["artifacts"])

--- a/tuxmake/target/kselftest-bpf.ini
+++ b/tuxmake/target/kselftest-bpf.ini
@@ -5,7 +5,9 @@ description = "Kernel BPF selftest (kselftest)"
 # config options are needed to run all BPF tests but not currently included
 # by the kselftest-merge target.
 dependencies = kernel headers
-commands = {make} -C tools/testing/selftests/ install
+nonfatal = true
+commands = {make} -C tools/testing/selftests/ all
+    && {make} -o all -C tools/testing/selftests/ install
     && {tar_caf} {build_dir}/kselftest-bpf.tar{z_ext} -C {build_dir}/kselftest_bpf_install .
 
 [makevars]

--- a/tuxmake/target/kselftest.ini
+++ b/tuxmake/target/kselftest.ini
@@ -2,7 +2,9 @@
 description = "Kernel selftest (kselftest)"
 dependencies = config
 runs_after = kselftest-merge
-commands = {make} -C tools/testing/selftests install
+nonfatal = true
+commands = {make} -C tools/testing/selftests all
+    && {make} -o all -C tools/testing/selftests install
     && {tar_caf} {build_dir}/kselftest.tar{z_ext} -C {build_dir}/kselftest_install .
 
 [makevars]


### PR DESCRIPTION
Many selftests do not cross-compile. The kernel kselftest Makefile now fails if any sub-target fails to build.

The install target depends on all. When all fails, make skips install and nothing gets packaged.

Split into two make steps. Run all first, then install with -o all to skip the dependency. Add a nonfatal flag so command failures do not stop the build.

Mark kselftest and kselftest-bpf as nonfatal.