### PR TITLE
target: accept any CONFIG_*=<value> inline fragment

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -211,6 +211,39 @@ class TestKconfig:
         config = output_dir / "config"
         assert "CONFIG_FOO=n\n" in config.read_text()
 
+    def test_kconfig_add_inline_set_to_int(self, linux, output_dir):
+        build(
+            tree=linux,
+            targets=["config"],
+            kconfig_add=["CONFIG_FOO=1", "CONFIG_BAR=0", "CONFIG_BAZ=128"],
+            output_dir=output_dir,
+        )
+        config = output_dir / "config"
+        text = config.read_text()
+        assert "CONFIG_FOO=1\n" in text
+        assert "CONFIG_BAR=0\n" in text
+        assert "CONFIG_BAZ=128\n" in text
+
+    def test_kconfig_add_inline_set_to_hex(self, linux, output_dir):
+        build(
+            tree=linux,
+            targets=["config"],
+            kconfig_add=["CONFIG_FOO=0xdeadbeef"],
+            output_dir=output_dir,
+        )
+        config = output_dir / "config"
+        assert "CONFIG_FOO=0xdeadbeef\n" in config.read_text()
+
+    def test_kconfig_add_inline_set_to_string(self, linux, output_dir):
+        build(
+            tree=linux,
+            targets=["config"],
+            kconfig_add=['CONFIG_FOO="hello world"'],
+            output_dir=output_dir,
+        )
+        config = output_dir / "config"
+        assert 'CONFIG_FOO="hello world"\n' in config.read_text()
+
     def test_kconfig_add_in_tree(self, linux, output_dir):
         build(
             tree=linux,
@@ -246,6 +279,18 @@ class TestKconfig:
     def test_kconfig_add_invalid(self, linux):
         with pytest.raises(tuxmake.exceptions.UnsupportedKconfigFragment):
             build(tree=linux, targets=["config"], kconfig_add=["foo"])
+
+    def test_kconfig_add_rejects_missing_prefix(self, linux):
+        with pytest.raises(tuxmake.exceptions.UnsupportedKconfigFragment):
+            build(tree=linux, targets=["config"], kconfig_add=["FOO=m"])
+
+    def test_kconfig_add_rejects_empty_name(self, linux):
+        with pytest.raises(tuxmake.exceptions.UnsupportedKconfigFragment):
+            build(tree=linux, targets=["config"], kconfig_add=["CONFIG_=y"])
+
+    def test_kconfig_add_rejects_empty_value(self, linux):
+        with pytest.raises(tuxmake.exceptions.UnsupportedKconfigFragment):
+            build(tree=linux, targets=["config"], kconfig_add=["CONFIG_FOO="])
 
     def test_kconfig_from_source_tree(self, linux):
         b = build(tree=linux, targets=["config"], kconfig="config/test.config")

--- a/tuxmake/target.py
+++ b/tuxmake/target.py
@@ -258,16 +258,11 @@ class Config(Target):
             return False
 
     def handle_inline_fragment(self, config, frag):
-        accepted_patterns = [
-            r"^CONFIG_\w+=[ymn]$",
-            r"^#\s*CONFIG_\w+\s*is\s*not\s*set\s*$",
-        ]
-        accepted = False
-        for pattern in accepted_patterns:
-            if re.match(pattern, frag):
-                accepted = True
-
-        if not accepted:
+        # Syntax-only check: kconfig (olddefconfig / merge_config.sh) is the real validator.
+        if not (
+            re.match(r"^CONFIG_\w+=.+$", frag)
+            or re.match(r"^#\s*CONFIG_\w+\s*is\s*not\s*set\s*$", frag)
+        ):
             return False
 
         with config.open("a") as f:


### PR DESCRIPTION
The old regex only matched =y/=m/=n and "is not set" lines. That misses a lot of real config: =1 and =0 are common for bools (kselftest's tools/testing/selftests/bpf/config uses =1 for
CONFIG_BOOTPARAM_SOFTLOCKUP_PANIC), and fragments can also include hex, string, and int symbols.

tuxmake was rejecting those as "Unsupported kconfig fragment" even though they work fine once they hit olddefconfig.

Let kconfig handle validation. merge_config.sh and olddefconfig already know each symbol's type and print a reasonable error when the value is wrong, so there's no point replicating that here. Keep the two shapes ("CONFIG_X=..." and "# CONFIG_X is not set") so pure junk still gets caught.