### PR TITLE
kselftest warning

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1058,6 +1058,37 @@ class TestKselftest:
         mocker.patch.object(b, "check_artifacts", return_value=True)
         result = b.build(target)
         assert result.passed
+        assert result.warning
+        assert not result.failed
+
+    def test_warning_does_not_block_dependent_targets(self, linux, mocker):
+        b = Build(tree=linux, targets=["config"])
+        b.status["kselftest"] = BuildInfo("WARNING")
+        target = mocker.MagicMock()
+        target.name = "next"
+        target.nonfatal = False
+        target.dependencies = ["kselftest"]
+        target.preconditions = []
+        target.commands = [Command(["true"])]
+        mocker.patch.object(b, "run_cmd", return_value=True)
+        mocker.patch.object(b, "check_artifacts", return_value=True)
+        result = b.build(target)
+        assert result.passed
+        assert not result.skipped
+
+    def test_warning_target_build_not_failed(self, linux):
+        b = Build(tree=linux, targets=["config"])
+        b.status["config"] = BuildInfo("PASS")
+        b.status["kselftest"] = BuildInfo("WARNING")
+        assert not b.failed
+        assert b.passed
+
+    def test_fail_overrides_warning(self, linux):
+        b = Build(tree=linux, targets=["config"])
+        b.status["config"] = BuildInfo("FAIL")
+        b.status["kselftest"] = BuildInfo("WARNING")
+        assert b.failed
+        assert not b.passed
 
 
 class TestHeaders:

--- a/tuxmake/build.py
+++ b/tuxmake/build.py
@@ -79,7 +79,7 @@ class BuildInfo:
         """
         `True` if this target passed.
         """
-        return self.status == "PASS"
+        return self.status in ("PASS", "WARNING")
 
     @property
     def skipped(self):
@@ -87,6 +87,13 @@ class BuildInfo:
         `True` if this target was skipped.
         """
         return self.status == "SKIP"
+
+    @property
+    def warning(self):
+        """
+        `True` if this target passed with warnings.
+        """
+        return self.status == "WARNING"
 
 
 class Build:
@@ -591,6 +598,7 @@ class Build:
         target.prepare()
 
         fail = False
+        had_nonfatal_failure = False
         exclude_keys = getattr(target, "exclude_build_makevars", set())
         for cmd in target.commands:
             if not self.run_cmd(
@@ -601,6 +609,7 @@ class Build:
             ):
                 if target.nonfatal:
                     self.log("W: command failed, continuing (nonfatal target)")
+                    had_nonfatal_failure = True
                 else:
                     fail = True
                     break
@@ -610,6 +619,9 @@ class Build:
 
         if fail:
             return BuildInfo("FAIL")
+
+        if had_nonfatal_failure:
+            return BuildInfo("WARNING")
 
         return BuildInfo("PASS")
 
@@ -667,7 +679,15 @@ class Build:
         }
         errors, warnings = self.parse_log()
         self.metadata["results"] = {
-            "status": "PASS" if self.passed else "FAIL",
+            "status": (
+                "FAIL"
+                if self.failed
+                else (
+                    "WARNING"
+                    if any(info.warning for info in self.status.values())
+                    else "PASS"
+                )
+            ),
             "targets": {
                 name: {"status": s.status, "duration": s.duration}
                 for name, s in self.status.items()

--- a/tuxmake/target/kselftest-bpf.ini
+++ b/tuxmake/target/kselftest-bpf.ini
@@ -7,7 +7,7 @@ description = "Kernel BPF selftest (kselftest)"
 dependencies = kernel headers
 nonfatal = true
 commands = {make} -C tools/testing/selftests/ all
-    && {make} -o all -C tools/testing/selftests/ install
+    && {make} -i -C tools/testing/selftests/ install
     && {tar_caf} {build_dir}/kselftest-bpf.tar{z_ext} -C {build_dir}/kselftest_bpf_install .
 
 [makevars]

--- a/tuxmake/target/kselftest.ini
+++ b/tuxmake/target/kselftest.ini
@@ -4,7 +4,7 @@ dependencies = config
 runs_after = kselftest-merge
 nonfatal = true
 commands = {make} -C tools/testing/selftests all
-    && {make} -o all -C tools/testing/selftests install
+    && {make} -i -C tools/testing/selftests install
     && {tar_caf} {build_dir}/kselftest.tar{z_ext} -C {build_dir}/kselftest_install .
 
 [makevars]


### PR DESCRIPTION
Summary of this PR
- Report WARNING status when kselftest has partial build failures.
- Use make -i for the install step so tests that compiled get installed