### PR TITLE
cmdline: update --kconfig-add help text

### DIFF
--- a/docs/kconfig.md
+++ b/docs/kconfig.md
@@ -26,7 +26,12 @@ ways:
 - a path to a config file on the local filesystem;
 - a URL to a config file, in which case TuxMake will download it;
 - a config fragment matching one of these:
-    - `CONFIG_*=[y|m|n]`
+    - `CONFIG_*=<value>`
+
+  `<value>` can be `y`, `m`, `n`, a number, a hex value, or a string.
+  TuxMake only checks the format. The value is passed to kconfig
+  (`merge_config.sh` and `make olddefconfig`), which decides what to do
+  with it.
     - `# CONFIG_* is not set`
 
 `kconfig_add` can be specified multiple times. Any in-tree configuration target

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -136,17 +136,6 @@ selftests because they require the most recent clang toolchain and a specific
 kernel configuration. The resulting, installed tests are compressed in a
 tarball which is copied into the output directory as `kselftest-bpf.tar.xz`.
 
-## kselftest-merge
-
-*DEPRECATED:* this target is deprecated. You should use
-`--kconfig-add=make:kselftest-merge` instead.
-
-This target merges some configuration required by `kselftest` in the kernel
-configuration. It will run after the `config` target. Note that `kselftest`
-does not require this, so if you want `kselftest-merge` to be built, it needs
-to be specified explicitly. If built, it will always be built before
-`kselftest` itself.
-
 ## clang-analyzer
 
 This target run check with clang static analyzer.

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1071,25 +1071,10 @@ class TestKernel:
 
 
 class TestKselftest:
-    def test_kselftest_merge_before_kselftest(self, linux):
-        build = Build(tree=linux, targets=["kselftest", "kselftest-merge"])
-        names = [t.name for t in build.targets][-2:]
-        assert names == ["kselftest-merge", "kselftest"]
-
-    def test_kselftest_merge_before_kselftest_with_input_already_ordered(self, linux):
-        build = Build(tree=linux, targets=["kselftest-merge", "kselftest"])
-        names = [t.name for t in build.targets][-2:]
-        assert names == ["kselftest-merge", "kselftest"]
-
-    def test_kselftest_without_kselftest_merge(self, linux):
+    def test_kselftest_depends_on_config(self, linux):
         build = Build(tree=linux, targets=["kselftest"])
         names = [t.name for t in build.targets]
         assert names == ["config", "kselftest"]
-
-    def test_kselftest_merge_runs_right_after_config_and_before_default(self, linux):
-        build = Build(tree=linux, targets=["config", "kernel", "kselftest-merge"])
-        names = [t.name for t in build.targets]
-        assert names == ["config", "kselftest-merge", "default", "kernel"]
 
     def test_nonfatal_continues_on_failure(self, linux, mocker):
         b = Build(tree=linux, targets=["config"])

--- a/tuxmake/cmdline.py
+++ b/tuxmake/cmdline.py
@@ -96,7 +96,7 @@ def build_parser(cls=argparse.ArgumentParser, **kwargs):
         "--kconfig-add",
         type=str,
         action="append",
-        help="Extra kconfig fragments, merged on top of the main kconfig from --kconfig. In tree configuration fragment (e.g. `kvm_guest.config`), path to local file, URL, `CONFIG_*=[y|m|n]`, or `# CONFIG_* is not set`. Can be specified multiple times, and will be merged in the order given.",
+        help="Extra kconfig fragments, merged on top of the main kconfig from --kconfig. In tree configuration fragment (e.g. `kvm_guest.config`), path to local file, URL, `CONFIG_*=<value>`, `# CONFIG_* is not set`, or `make:<target>` to run a make target that modifies .config (e.g. `make:kselftest-merge`). Can be specified multiple times, and will be merged in the order given.",
     )
     target.add_argument(
         "-I",

--- a/tuxmake/target/default.ini
+++ b/tuxmake/target/default.ini
@@ -1,5 +1,4 @@
 [target]
 description = "Default target"
 dependencies = config
-runs_after = kselftest-merge
 commands = {make}

--- a/tuxmake/target/kselftest-bpf.ini
+++ b/tuxmake/target/kselftest-bpf.ini
@@ -1,9 +1,7 @@
 [target]
 description = "Kernel BPF selftest (kselftest)"
 # Some BPF tests use BTF data (type information) from the generated kernel
-# image, hence the dependency to kernel and CONFIG_DEBUG_INFO_BTF. The other
-# config options are needed to run all BPF tests but not currently included
-# by the kselftest-merge target.
+# image, hence the dependency to kernel and CONFIG_DEBUG_INFO_BTF.
 dependencies = kernel headers
 nonfatal = true
 commands = {make} -C tools/testing/selftests/ all

--- a/tuxmake/target/kselftest-merge.ini
+++ b/tuxmake/target/kselftest-merge.ini
@@ -1,5 +1,0 @@
-[target]
-description = "Kernel selftest merge configuration"
-dependencies = config
-commands = echo "tuxmake: warning: the kselftest-merge target is deprecated. Use --kconfig-add=make:kselftest-merge instead"
-    && {make} kselftest-merge

--- a/tuxmake/target/kselftest.ini
+++ b/tuxmake/target/kselftest.ini
@@ -1,7 +1,6 @@
 [target]
 description = "Kernel selftest (kselftest)"
 dependencies = config
-runs_after = kselftest-merge
 nonfatal = true
 commands = {make} -C tools/testing/selftests all
     && {make} -i -C tools/testing/selftests install


### PR DESCRIPTION
Document the make:<target> syntax for running make targets that modify .config (e.g. make:kselftest-merge). Also update the inline config example from CONFIG_*=[y|m|n] to CONFIG_*=<value> to reflect that any value is now accepted.