### PR TITLE
runtime: skip parisc for gcc-16

### DIFF
--- a/tuxmake/runtime/docker.ini
+++ b/tuxmake/runtime/docker.ini
@@ -231,8 +231,10 @@ kind = gcc-build
 base = base-debiantesting
 hosts = amd64, arm64
 # targets: no mips for now, see target_skip
+# parisc: binutils 2.46 ld.bfd cannot link for hppa (.PARISC.unwind too
+# large); skip until the upstream toolchain bug is fixed
 targets = arc, x86_64, arm64, arm, armv5, i386, mips, powerpc, riscv, m68k, parisc, sh, sparc, s390
-target_skip = mips
+target_skip = mips, parisc
 rebuild = monthly
 packages = gcc-16, g++-16
 boot_test = False


### PR DESCRIPTION
binutils 2.46 ld.bfd cannot link a freestanding program for hppa. It fails with ".PARISC.unwind too large" and "final link failed", so the parisc_gcc-16 image fails its environment check.

Add parisc to target_skip for gcc-16 so the image is not built or published until the toolchain is fixed. This is an upstream toolchain bug, not a tuxmake problem.