### PR TITLE
ci: use debian trixie for packages and trigger jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,7 +275,7 @@ pkg:
       - dist/*.pkg.tar.zst
 
 packages:
-  image: debian:bullseye
+  image: debian:trixie
   stage: build
   extends: .tuxmake
   only:
@@ -294,7 +294,7 @@ packages:
 
 trigger_tuxsuite:
   stage: .post
-  image: debian:bullseye
+  image: debian:trixie
   before_script:
     - apt update
     - apt install -y curl


### PR DESCRIPTION
The packages and trigger_tuxsuite jobs only run dpkg-dev and curl. They used bullseye, which is old now and served from archive.debian.org. Downloads are slow and flaky.

Use trixie instead.