### PR TITLE
build: log the compiler version at the start of build.log

### DIFF
--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -109,6 +109,13 @@ class TestEarlyMetadataWrite:
         assert "results" not in data
 
 
+class TestCompilerInBuildLog:
+    def test_compiler_logged(self, build):
+        log = (build.output_dir / "build.log").read_text()
+        version_full = build.metadata["compiler"]["version_full"]
+        assert f"# compiler: {version_full}" in log
+
+
 class TestKernelVersion:
     def test_happy_path(self, build):
         assert type(build.metadata["source"]["kernelversion"]) is str

--- a/tuxmake/build.py
+++ b/tuxmake/build.py
@@ -849,6 +849,10 @@ class Build:
                 self.collect_metadata_early()
             self.save_metadata()
 
+            version_full = self.metadata.get("compiler", {}).get("version_full")
+            if version_full:
+                self.log(f"# compiler: {version_full}")
+
             with self.go_offline():
                 with self.measure_duration("Build", metadata="build"):
                     self.build_all_targets()


### PR DESCRIPTION
We already collect the compiler version after prepare(). Write it to build.log before the build starts.

Now you see which compiler was used at the top of the log, without opening metadata.json.

The idea came from Ben's commit in the kernelci project.