### PR TITLE
ci: require python 3.11 and test 3.11 to 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,44 +52,66 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    container:
-      image: registry.gitlab.com/linaro/tuxmake/ci-debian-12
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make shunit2 git ccache gcc perl findutils xz-utils bzip2
       - name: Install dependencies
         run: |
-          pip install -e . --break-system-packages
-          pip install -r requirements-dev.txt --break-system-packages
+          pip install -e .
+          pip install pytest pytest-cov pytest-mock
       - name: Run unit tests
         run: make unit-tests
 
   unit-tests-arm64:
     runs-on: ubuntu-24.04-arm
-    container:
-      image: registry.gitlab.com/linaro/tuxmake/ci-debian-12
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make shunit2 git ccache gcc perl findutils xz-utils bzip2
       - name: Install dependencies
         run: |
-          pip install -e . --break-system-packages
-          pip install -r requirements-dev.txt --break-system-packages
+          pip install -e .
+          pip install pytest pytest-cov pytest-mock
       - name: Run unit tests
         run: make unit-tests
 
   integration-tests:
     runs-on: ubuntu-latest
-    container:
-      image: registry.gitlab.com/linaro/tuxmake/ci-debian-12
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make shunit2 git ccache gcc perl findutils xz-utils bzip2 socat \
+            gcc-x86-64-linux-gnu gcc-aarch64-linux-gnu clang lld
       - name: Install tuxmake
-        run: pip install -e . --break-system-packages
+        run: pip install -e .
       - name: Run integration tests
         run: make integration-tests TMV=1
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,53 +36,21 @@ stages:
   script:
     - make unit-tests
 
+unit-tests-python3.12:
+  extends: .unit-tests
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-24.04
+
 unit-tests-python3.11:
   extends: .unit-tests
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
 
-unit-tests-python3.10:
-  extends: .unit-tests
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-22.04
-
-unit-tests-python3.9:
-  extends: .unit-tests
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-11
-
-unit-tests-python3.8:
-  extends: .unit-tests
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-20.04
-
-unit-tests-python3.7:
-  extends: .unit-tests
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-10
-
-unit-tests-python3.6:
-  extends: .unit-tests
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-18.04
+unit-tests-python3.12-arm64:
+  extends: [.unit-tests, .arm64]
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-24.04
 
 unit-tests-python3.11-arm64:
   extends: [.unit-tests, .arm64]
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
-
-unit-tests-python3.10-arm64:
-  extends: [.unit-tests, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-22.04
-
-unit-tests-python3.9-arm64:
-  extends: [.unit-tests, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-11
-
-unit-tests-python3.8-arm64:
-  extends: [.unit-tests, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-20.04
-
-unit-tests-python3.7-arm64:
-  extends: [.unit-tests, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-10
-
-unit-tests-python3.6-arm64:
-  extends: [.unit-tests, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-18.04
 
 .code-checks:
   extends: .tuxmake
@@ -129,56 +97,24 @@ docker-build-tests:
     - flit --debug build
     - python3 -m pip install dist/*.whl --break-system-packages
 
+integration-python3.12:
+  extends: .integration-break-system-packages
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-24.04
+
 integration-python3.11:
   extends: .integration-break-system-packages
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
 
-integration-python3.10:
-  extends: .integration
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-22.04
-
-integration-python3.9:
-  extends: .integration
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-11
-
-integration-python3.8:
-  extends: .integration
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-20.04
-
-integration-python3.7:
-  extends: .integration
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-10
-
-integration-python3.6:
-  extends: .integration
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-10
+integration-python3.12-arm64:
+  extends: [.integration-break-system-packages, .arm64]
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-24.04
 
 integration-python3.11-arm64:
   extends: [.integration-break-system-packages, .arm64]
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
 
-integration-python3.10-arm64:
-  extends: [.integration, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-22.04
-
-integration-python3.9-arm64:
-  extends: [.integration, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-11
-
-integration-python3.8-arm64:
-  extends: [.integration, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-20.04
-
-integration-python3.7-arm64:
-  extends: [.integration, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-10
-
-integration-python3.6-arm64:
-  extends: [.integration, .arm64]
-  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-18.04
-
 integration-docker:
-  extends: integration-python3.8
+  extends: integration-python3.11
   services:
     - name: docker:20.10-dind
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,10 @@ stages:
   script:
     - make unit-tests
 
+unit-tests-python3.14:
+  extends: .unit-tests
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-26.04
+
 unit-tests-python3.13:
   extends: .unit-tests
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-13
@@ -47,6 +51,10 @@ unit-tests-python3.12:
 unit-tests-python3.11:
   extends: .unit-tests
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
+
+unit-tests-python3.14-arm64:
+  extends: [.unit-tests, .arm64]
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-26.04
 
 unit-tests-python3.13-arm64:
   extends: [.unit-tests, .arm64]
@@ -105,6 +113,10 @@ docker-build-tests:
     - flit --debug build
     - python3 -m pip install dist/*.whl --break-system-packages
 
+integration-python3.14:
+  extends: .integration-break-system-packages
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-26.04
+
 integration-python3.13:
   extends: .integration-break-system-packages
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-13
@@ -116,6 +128,10 @@ integration-python3.12:
 integration-python3.11:
   extends: .integration-break-system-packages
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
+
+integration-python3.14-arm64:
+  extends: [.integration-break-system-packages, .arm64]
+  image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-26.04
 
 integration-python3.13-arm64:
   extends: [.integration-break-system-packages, .arm64]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,10 @@ stages:
   script:
     - make unit-tests
 
+unit-tests-python3.13:
+  extends: .unit-tests
+  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-13
+
 unit-tests-python3.12:
   extends: .unit-tests
   image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-24.04
@@ -43,6 +47,10 @@ unit-tests-python3.12:
 unit-tests-python3.11:
   extends: .unit-tests
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
+
+unit-tests-python3.13-arm64:
+  extends: [.unit-tests, .arm64]
+  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-13
 
 unit-tests-python3.12-arm64:
   extends: [.unit-tests, .arm64]
@@ -97,6 +105,10 @@ docker-build-tests:
     - flit --debug build
     - python3 -m pip install dist/*.whl --break-system-packages
 
+integration-python3.13:
+  extends: .integration-break-system-packages
+  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-13
+
 integration-python3.12:
   extends: .integration-break-system-packages
   image: $CI_REGISTRY/linaro/tuxmake/ci-ubuntu-24.04
@@ -104,6 +116,10 @@ integration-python3.12:
 integration-python3.11:
   extends: .integration-break-system-packages
   image: $CI_REGISTRY/linaro/tuxmake/ci-debian-12
+
+integration-python3.13-arm64:
+  extends: [.integration-break-system-packages, .arm64]
+  image: $CI_REGISTRY/linaro/tuxmake/ci-debian-13
 
 integration-python3.12-arm64:
   extends: [.integration-break-system-packages, .arm64]

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: https://tuxmake.org/
 
 Package: tuxmake
 Architecture: all
-Depends: ${misc:Depends}, ${perl:Depends}, python3 (>= 3.6), ${python3:Depends}
+Depends: ${misc:Depends}, ${perl:Depends}, python3 (>= 3.11), ${python3:Depends}
 Recommends: socat
 Description: Thin wrapper to build Linux kernels
  TuxMake is a command line tool and Python library that provides portable and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 readme = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires-python = ">=3.6"
+requires-python = ">=3.11"
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/support/docker/tuxmake-ci-images.yml
+++ b/support/docker/tuxmake-ci-images.yml
@@ -46,19 +46,6 @@
   variables:
     ARCH: arm64
 
-ci-debian-10-amd64:
-  extends: .build-ci-image-amd64
-  variables:
-    BASE: docker.io/library/debian:buster-slim
-
-ci-debian-10-arm64:
-  extends: .build-ci-image-arm64
-  variables:
-    BASE: docker.io/library/debian:buster-slim
-
-ci-debian-10:
-  extends: .publish-ci-image
-
 ci-debian-11-amd64:
   extends: .build-ci-image-amd64
   variables:
@@ -83,45 +70,6 @@ ci-debian-12-arm64:
     BASE: docker.io/library/debian:bookworm-slim
 
 ci-debian-12:
-  extends: .publish-ci-image
-
-ci-ubuntu-18.04-amd64:
-  extends: .build-ci-image-amd64
-  variables:
-    BASE: docker.io/library/ubuntu:18.04
-
-ci-ubuntu-18.04-arm64:
-  extends: .build-ci-image-arm64
-  variables:
-    BASE: docker.io/library/ubuntu:18.04
-
-ci-ubuntu-18.04:
-  extends: .publish-ci-image
-
-ci-ubuntu-20.04-amd64:
-  extends: .build-ci-image-amd64
-  variables:
-    BASE: docker.io/library/ubuntu:20.04
-
-ci-ubuntu-20.04-arm64:
-  extends: .build-ci-image-arm64
-  variables:
-    BASE: docker.io/library/ubuntu:20.04
-
-ci-ubuntu-20.04:
-  extends: .publish-ci-image
-
-ci-ubuntu-22.04-amd64:
-  extends: .build-ci-image-amd64
-  variables:
-    BASE: docker.io/library/ubuntu:22.04
-
-ci-ubuntu-22.04-arm64:
-  extends: .build-ci-image-arm64
-  variables:
-    BASE: docker.io/library/ubuntu:22.04
-
-ci-ubuntu-22.04:
   extends: .publish-ci-image
 
 ci-ubuntu-24.04-amd64:

--- a/support/docker/tuxmake-ci-images.yml
+++ b/support/docker/tuxmake-ci-images.yml
@@ -97,3 +97,16 @@ ci-ubuntu-24.04-arm64:
 
 ci-ubuntu-24.04:
   extends: .publish-ci-image
+
+ci-ubuntu-26.04-amd64:
+  extends: .build-ci-image-amd64
+  variables:
+    BASE: docker.io/library/ubuntu:26.04
+
+ci-ubuntu-26.04-arm64:
+  extends: .build-ci-image-arm64
+  variables:
+    BASE: docker.io/library/ubuntu:26.04
+
+ci-ubuntu-26.04:
+  extends: .publish-ci-image

--- a/support/docker/tuxmake-ci-images.yml
+++ b/support/docker/tuxmake-ci-images.yml
@@ -72,6 +72,19 @@ ci-debian-12-arm64:
 ci-debian-12:
   extends: .publish-ci-image
 
+ci-debian-13-amd64:
+  extends: .build-ci-image-amd64
+  variables:
+    BASE: docker.io/library/debian:trixie-slim
+
+ci-debian-13-arm64:
+  extends: .build-ci-image-arm64
+  variables:
+    BASE: docker.io/library/debian:trixie-slim
+
+ci-debian-13:
+  extends: .publish-ci-image
+
 ci-ubuntu-24.04-amd64:
   extends: .build-ci-image-amd64
   variables:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,10 @@ def session_home(tmpdir_factory):
 def home(monkeypatch, tmp_path):
     h = tmp_path / "HOME"
     monkeypatch.setenv("HOME", str(h))
+    # The config and cache dirs live under HOME. Drop the XDG variables
+    # so a value in the environment does not point the tests elsewhere.
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
     return h
 
 

--- a/test/integration/fakelinux
+++ b/test/integration/fakelinux
@@ -170,6 +170,7 @@ test_custom_kernel_image() {
 test_no_network_access() {
   skip_if docker_runtime
   skip_if under_docker
+  skip_if offline_unavailable
 
   sed -i -e 's#\S*call maybefail,debugkernel.*#wget http://tuxmake.org/#' Makefile
   run tuxmake

--- a/test/integration/test_helper.sh
+++ b/test/integration/test_helper.sh
@@ -93,6 +93,11 @@ docker_in_docker() {
   docker_runtime && under_docker
 }
 
+offline_unavailable() {
+  # the offline test needs socat and a private network namespace
+  ! "${base}/tuxmake/runtime/bin/tuxmake-run-offline" true
+}
+
 program_installed() {
   /usr/bin/which "${@}" > /dev/null
 }

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -130,8 +130,9 @@ class TestDownloadFileWithProgress:
         mock_response.__enter__ = lambda x: mock_response
         mock_response.__exit__ = lambda x, y, z, w: None
 
-        with patch("urllib.request.Request") as mock_request, patch(
-            "urllib.request.urlopen", return_value=mock_response
+        with (
+            patch("urllib.request.Request") as mock_request,
+            patch("urllib.request.urlopen", return_value=mock_response),
         ):
             download_file_with_progress(
                 "http://example.com/file.txt", output_path, mock_logger
@@ -163,8 +164,9 @@ class TestDownloadFileWithProgress:
         mock_response.__enter__ = lambda x: mock_response
         mock_response.__exit__ = lambda x, y, z, w: None
 
-        with patch("urllib.request.Request"), patch(
-            "urllib.request.urlopen", return_value=mock_response
+        with (
+            patch("urllib.request.Request"),
+            patch("urllib.request.urlopen", return_value=mock_response),
         ):
             download_file_with_progress(
                 "http://example.com/file.txt", output_path, mock_logger
@@ -183,9 +185,11 @@ class TestDownloadFileWithProgress:
         mock_response.__enter__ = lambda x: mock_response
         mock_response.__exit__ = lambda x, y, z, w: None
 
-        with patch("urllib.request.Request"), patch(
-            "urllib.request.urlopen", return_value=mock_response
-        ), patch("builtins.print") as mock_print:
+        with (
+            patch("urllib.request.Request"),
+            patch("urllib.request.urlopen", return_value=mock_response),
+            patch("builtins.print") as mock_print,
+        ):
             download_file_with_progress("http://example.com/file.txt", output_path)
 
         assert output_path.read_bytes() == test_content

--- a/tuxmake.spec
+++ b/tuxmake.spec
@@ -21,7 +21,7 @@ BuildRequires: wget
 
 BuildArch: noarch
 
-Requires: python3 >= 3.6
+Requires: python3 >= 3.11
 Requires: perl-JSON-PP
 Recommends: socat
 


### PR DESCRIPTION
Clean up the python versions we support and test.
Set the minimum requirement to python 3.11.