### PR TITLE
docker: stop building EOL containers

### DIFF
--- a/support/docker/test/test_configure.sh
+++ b/support/docker/test/test_configure.sh
@@ -42,9 +42,9 @@ test_gcc() {
     assertArg 'BASE=$(DOCKER_REGISTRY)$(PROJECT)/base' 'PACKAGES="gcc g++"'
 }
 
-test_gcc_11() {
-    get_build_args gcc-11
-    assertArg 'BASE=$(DOCKER_REGISTRY)$(PROJECT)/base-debian' 'PACKAGES="gcc-11 g++-11"'
+test_gcc_14() {
+    get_build_args gcc-14
+    assertArg 'BASE=$(DOCKER_REGISTRY)$(PROJECT)/base-debian' 'PACKAGES="gcc-14 g++-14"'
 }
 
 test_arm64_gcc() {

--- a/support/docker/tuxmake-images.yml
+++ b/support/docker/tuxmake-images.yml
@@ -645,45 +645,6 @@ docker-images-clang_nightly_all-multiarch:
         - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "daily" || $TUXMAKE_DOCKER_IMAGES == "clang_nightly_all")'
 
 
-docker-images-gcc_12_all-amd64:
-    stage: build
-    extends: .docker
-    variables:
-        TAG: "-amd64"
-    script:
-        - "make publish-gcc_12_all"
-    tags: [saas-linux-medium-amd64]
-    needs: ['docker-images-base-multiarch']
-    rules:
-        - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "monthly" || $TUXMAKE_DOCKER_IMAGES == "gcc_12_all")'
-
-
-docker-images-gcc_12_all-arm64:
-    stage: build
-    extends: .docker
-    variables:
-        TAG: "-arm64"
-    script:
-        - "make publish-gcc_12_all"
-    tags: [saas-linux-medium-arm64]
-    needs: ['docker-images-base-multiarch']
-    rules:
-        - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "monthly" || $TUXMAKE_DOCKER_IMAGES == "gcc_12_all")'
-
-
-docker-images-gcc_12_all-multiarch:
-    stage: publish
-    extends: .docker
-    variables:
-        DOCKER_CLI_EXPERIMENTAL: "enabled"
-        ARCH_TAGS: "-amd64 -arm64"
-    script:
-        - "make publish-multiarch-gcc_12_all"
-    needs: ['docker-images-gcc_12_all-amd64', 'docker-images-gcc_12_all-arm64']
-    rules:
-        - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "monthly" || $TUXMAKE_DOCKER_IMAGES == "gcc_12_all")'
-
-
 docker-images-gcc_13_all-amd64:
     stage: build
     extends: .docker

--- a/support/docker/tuxmake-images.yml
+++ b/support/docker/tuxmake-images.yml
@@ -645,45 +645,6 @@ docker-images-clang_nightly_all-multiarch:
         - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "daily" || $TUXMAKE_DOCKER_IMAGES == "clang_nightly_all")'
 
 
-docker-images-gcc_11_all-amd64:
-    stage: build
-    extends: .docker
-    variables:
-        TAG: "-amd64"
-    script:
-        - "make publish-gcc_11_all"
-    tags: [saas-linux-medium-amd64]
-    needs: ['docker-images-base-multiarch']
-    rules:
-        - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "monthly" || $TUXMAKE_DOCKER_IMAGES == "gcc_11_all")'
-
-
-docker-images-gcc_11_all-arm64:
-    stage: build
-    extends: .docker
-    variables:
-        TAG: "-arm64"
-    script:
-        - "make publish-gcc_11_all"
-    tags: [saas-linux-medium-arm64]
-    needs: ['docker-images-base-multiarch']
-    rules:
-        - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "monthly" || $TUXMAKE_DOCKER_IMAGES == "gcc_11_all")'
-
-
-docker-images-gcc_11_all-multiarch:
-    stage: publish
-    extends: .docker
-    variables:
-        DOCKER_CLI_EXPERIMENTAL: "enabled"
-        ARCH_TAGS: "-amd64 -arm64"
-    script:
-        - "make publish-multiarch-gcc_11_all"
-    needs: ['docker-images-gcc_11_all-amd64', 'docker-images-gcc_11_all-arm64']
-    rules:
-        - if: '$CI_PIPELINE_SOURCE == "schedule" && ($TUXMAKE_DOCKER_IMAGES == "monthly" || $TUXMAKE_DOCKER_IMAGES == "gcc_11_all")'
-
-
 docker-images-gcc_12_all-amd64:
     stage: build
     extends: .docker

--- a/tuxmake/runtime/docker.ini
+++ b/tuxmake/runtime/docker.ini
@@ -135,7 +135,7 @@ hosts   = amd64, arm64
 rebuild = monthly
 targets = x86_64, arm64, i386, arm, armhf, armv5, armel, mips, riscv, arc, parisc, powerpc, s390, sh, sparc
 target_skip = arc
-target_bases = riscv:gcc-12, arc:gcc-9
+target_bases = riscv:gcc-13, arc:gcc-9
 target_kinds = arc:arc
 target_hosts = mips:amd64, arc:amd64, parisc:amd64, powerpc:amd64, s390:amd64, sh:amd64, sparc:amd64
 packages = gcc, g++
@@ -187,6 +187,7 @@ rebuild = monthly
 packages = gcc-11, g++-11
 
 [gcc-12]
+skip_build = True
 kind = gcc-build
 base = base-debian12
 hosts = amd64, arm64

--- a/tuxmake/runtime/docker.ini
+++ b/tuxmake/runtime/docker.ini
@@ -176,6 +176,7 @@ rebuild = monthly
 packages = gcc-10, g++-10
 
 [gcc-11]
+skip_build = True
 kind = gcc-build
 base = base-debian12
 hosts = amd64, arm64

--- a/tuxmake/runtime/docker.ini
+++ b/tuxmake/runtime/docker.ini
@@ -98,6 +98,7 @@ hosts   = amd64, arm64
 rebuild = monthly
 
 [base-debian11]
+skip_build = True
 kind    = base
 base    = docker.io/library/debian:bullseye-slim
 hosts   = amd64, arm64


### PR DESCRIPTION
base-debian11, gcc-11 and gcc-12 are end of life.
base-debian11 also can't meet the python 3.11 requirement.
Stop building them. Move riscv from gcc-12 to gcc-13.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>